### PR TITLE
Fixes to align with latest API version

### DIFF
--- a/src/main/java/org/geeek/btce/api/BtceClientApi.java
+++ b/src/main/java/org/geeek/btce/api/BtceClientApi.java
@@ -228,12 +228,12 @@ public class BtceClientApi {
      * @throws BtceFunctionalException
      * @throws BtceTechnicalException
      */
-    public Map<String,PairInfo> getInfo() throws BtceFunctionalException, BtceTechnicalException{
+    public Map<Pair,PairInfo> getInfo() throws BtceFunctionalException, BtceTechnicalException{
         
     	JSONObject jsonObject = publicHTTPRequest(PublicMethod.info, null);
-    	Map<String,PairInfo> pairInfo;
+    	Map<Pair,PairInfo> pairInfo;
 		try {
-			pairInfo = _mapper.readValue(jsonObject.getJSONObject("pairs").toString(), new TypeReference<Map<String,PairInfo>>() { });
+			pairInfo = _mapper.readValue(jsonObject.getJSONObject("pairs").toString(), new TypeReference<Map<Pair,PairInfo>>() { });
 		} catch (JsonParseException e) {
 			throw new BtceTechnicalException("BTC-e Json parse exeption", e);
 		} catch (JsonMappingException e) {

--- a/src/main/java/org/geeek/btce/api/BtceClientTradeApi.java
+++ b/src/main/java/org/geeek/btce/api/BtceClientTradeApi.java
@@ -59,7 +59,7 @@ public class BtceClientTradeApi {
 	private final static String API_URI = "https://btc-e.com/tapi/";
 	
 	// Nonce token  
-	private long _nonce = 0;
+	private long _nonce = 1;
 
 	// Private API Key
 	private String _key;
@@ -224,12 +224,12 @@ public class BtceClientTradeApi {
 	private boolean checkNonceError(String errorMessage) {
 		
 		// If nonce error, we increment the once value
-		Pattern r  = Pattern.compile("invalid nonce parameter; on key:(\\d+), you sent:(\\d+)");
+		Pattern r  = Pattern.compile("invalid nonce parameter; .+, you should send:(\\d+)");
 		Matcher m = r.matcher(errorMessage);
 				
 		if (m.find()){
 			LOGGER.warn("Invalid nonce parameter, we use the good one");
-			_nonce = Long.parseLong(m.group(1)) + 1;
+			_nonce = Long.parseLong(m.group(1));
 			return true;
 		}
 		

--- a/src/main/java/org/geeek/btce/enums/Pair.java
+++ b/src/main/java/org/geeek/btce/enums/Pair.java
@@ -26,6 +26,8 @@ public enum Pair {
 	/** EUR */
 	eur_usd,
 	
+	eur_rur,
+	
 	/** TRC */
 	trc_btc,
 	

--- a/src/main/java/org/geeek/btce/model/Funds.java
+++ b/src/main/java/org/geeek/btce/model/Funds.java
@@ -39,6 +39,10 @@ public class Funds {
 	
 	/** XPM fund. */
 	private double xpm;
+	
+	private double cnh;
+
+	private double gbp;
 
 	/**
 	 * @return the usd
@@ -192,6 +196,22 @@ public class Funds {
 	 */
 	public void setXpm(double xpm) {
 		this.xpm = xpm;
+	}
+
+	public double getCnh() {
+		return cnh;
+	}
+
+	public void setCnh(double cnh) {
+		this.cnh = cnh;
+	}
+
+	public double getGbp() {
+		return gbp;
+	}
+
+	public void setGbp(double gbp) {
+		this.gbp = gbp;
 	}
 
 }

--- a/src/test/java/org/geeek/btce/api/BtceClientApiTest.java
+++ b/src/test/java/org/geeek/btce/api/BtceClientApiTest.java
@@ -129,16 +129,16 @@ public class BtceClientApiTest {
 	public void testGetInfo() throws BtceFunctionalException, BtceTechnicalException {
 		
 		// Get the pair information
-		Map<String,PairInfo>  pairInfo = btceClientApi.getInfo();
+		Map<Pair,PairInfo>  pairInfo = btceClientApi.getInfo();
 		
 		assertNotNull(pairInfo);
-		assertNotNull(pairInfo.get("btc_usd"));
-		assertTrue(pairInfo.get("btc_usd").getDecimal_places() == 3);
-		assertTrue(pairInfo.get("btc_usd").getMin_price() == 0.1);
-		assertTrue(pairInfo.get("btc_usd").getMax_price() == 3200);
-		assertTrue(pairInfo.get("btc_usd").getMin_amount() == 0.01);
-		assertFalse(pairInfo.get("btc_usd").isHidden());
-		assertTrue(pairInfo.get("btc_usd").getFee() == 0.2);
+		assertNotNull(pairInfo.get(Pair.btc_usd));
+		assertTrue(pairInfo.get(Pair.btc_usd).getDecimal_places() == 3);
+		assertTrue(pairInfo.get(Pair.btc_usd).getMin_price() == 0.1);
+		assertTrue(pairInfo.get(Pair.btc_usd).getMax_price() == 3200);
+		assertTrue(pairInfo.get(Pair.btc_usd).getMin_amount() == 0.01);
+		assertFalse(pairInfo.get(Pair.btc_usd).isHidden());
+		assertTrue(pairInfo.get(Pair.btc_usd).getFee() == 0.2);
 	}
 	
 


### PR DESCRIPTION
A few changes to get this API working well for me:
- Fixed nonce generation/synchronisation
- Added a few ccys that weren't there.
- getInfo() now returns a Map<Pair, PairInfo>, which is not backward compatible.
